### PR TITLE
Corrected FAIRSharing URL.

### DIFF
--- a/scripts/views/main.html
+++ b/scripts/views/main.html
@@ -135,7 +135,7 @@
                             FAIRsharing curators by <a href="mailto:contact@fairsharing.org">email</a> they will
                             harvest the information from the GitHub and help with the registration process. The new
                             Maturity Indicator will be added to the
-                            existent <a href="https://fairsharing.org/standards/?q=&selected_facets=type_exact:metric" target="_blank">list of Maturity Indicator</a> with the "in development" tag.
+                            existent <a href="https://fairsharing.org/search?fairsharingRegistry=Standard&recordType=metric&page=1" target="_blank">list of Maturity Indicator</a> with the "in development" tag.
                             <br>
                             At this time, there is no formal process for adoption of Maturity Indicators
                             (incuding those that the Authoring Group have designed themselves!), as there is


### PR DESCRIPTION
The FAIRsharing URL here is for the old version of our site; I've updated it for the current site. 